### PR TITLE
Free the Roles! (Just in the frontend)

### DIFF
--- a/src/components/Builder/Wizard.vue
+++ b/src/components/Builder/Wizard.vue
@@ -77,7 +77,7 @@
       roleOptions() {
         return stores.cards({ type: 'role' }).map(role => ({
           value: role.id,
-          text: role.name + (this.clanRoles.filter(roleCard => roleCard.primary_role.id === role.id || roleCard.secondary_role.id === role.id).length > 0 ? ' (Current Clan Role)' : ''),
+          text: role.name
         }));
       },
     },


### PR DESCRIPTION
Quick fix to remove the "(Current Clan Role)" in the role wizard. Does not change the underlying data structure